### PR TITLE
Dodany link do rejestracji w programie darmowych szkolen Pluralsight

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Jak zrobić PR?
 
 - Darmowe kursy Microsoft na [Microsoft Learn](https://docs.microsoft.com/en-us/learn/)
 - [Azure JumpStart](https://marczak.io/posts/2019/07/azure-jumpstart/) by @MarczakIO
+- Darmowe szkolenia wideo w [Pluralsight](https://www.pluralsight.com/partners/microsoft/azure)
 
 **Co śledzić w temacie Azure?**
 


### PR DESCRIPTION
Mały up :>
W ramach współpracy z MS dostępnych jest w tej chwili 248 kursów wideo o łącznej długości ponad 494 godzin. Wszystko za friko, na pięć lat. Wystarczy zarejestrować nowe lub istniejące konto Pluralsight.